### PR TITLE
Fix detecting closed connection while sending

### DIFF
--- a/src/ingress.rs
+++ b/src/ingress.rs
@@ -78,8 +78,9 @@ impl<'a, Rx> Ingress<'a, Rx>
                 | Response::FirmwareInfo(..)
                 | Response::Connect(..)
                 | Response::ReadyForData
+                | Response::ReceivedDataToSend(..)
                 | Response::DataReceived(..)
-                | Response::SendOk(..)
+                | Response::SendOk
                 | Response::SendFail
                 | Response::WifiConnectionFailure(..)
                 | Response::IpAddress(..)

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -217,17 +217,27 @@ named!(
 );
 
 named!(
-    pub send_ok<Response>,
+    pub received_data_to_send<Response>,
     do_parse!(
-        crlf >>
+        opt!( crlf ) >>
         tag!("Recv ") >>
         len: parse_usize >>
         tag!(" bytes") >>
-        crlf >> crlf >>
+        crlf >>
+        (
+            Response::ReceivedDataToSend(len)
+        )
+    )
+);
+
+named!(
+    pub send_ok<Response>,
+    do_parse!(
+        opt!( crlf ) >>
         tag!("SEND OK") >>
         crlf >>
         (
-            Response::SendOk(len)
+            Response::SendOk
         )
     )
 );
@@ -235,13 +245,7 @@ named!(
 named!(
     pub send_fail<Response>,
     do_parse!(
-        crlf >>
-        tag!("Recv ") >>
-        len: parse_usize >>
-        tag!(" bytes") >>
-        crlf >>
-        //opt!(closed) >>
-        //opt!(crlf) >>
+        opt!( crlf ) >>
         tag!("SEND FAIL") >>
         crlf >>
         (
@@ -366,6 +370,7 @@ named!(
         | connect
         | closed
         | ready_for_data
+        | received_data_to_send
         | send_ok
         | send_fail
         | data_available

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -133,7 +133,8 @@ pub enum Response {
     Error,
     FirmwareInfo(FirmwareInfo),
     ReadyForData,
-    SendOk(usize),
+    ReceivedDataToSend(usize),
+    SendOk,
     SendFail,
     DataAvailable { link_id: usize, len: usize },
     DataReceived([u8; 512], usize),
@@ -157,7 +158,8 @@ impl Debug for Response {
             Response::Error => f.write_str("Error"),
             Response::FirmwareInfo(v) => f.debug_tuple("FirmwareInfo").field(v).finish(),
             Response::ReadyForData => f.write_str("ReadyForData"),
-            Response::SendOk(v) => f.debug_tuple("SendOk").field(v).finish(),
+            Response::ReceivedDataToSend(len) => f.debug_tuple("ReceivedDataToSend").field(len).finish(),
+            Response::SendOk =>f.write_str("SendOk"),
             Response::SendFail => f.write_str("SendFail"),
             Response::DataAvailable { link_id, len } => f
                 .debug_struct("DataAvailable")


### PR DESCRIPTION
The approach now is:
* Decode "Received to send", "Closed", and "Send Ok"/"Send fail" independently
* When sending, continue reading events until either "send ok" or an unknown event is read (fail in the latter)
* "Closed" events are already handled by the notification queue