### PR TITLE
Close the socket on the ESP

### DIFF
--- a/src/ingress.rs
+++ b/src/ingress.rs
@@ -86,6 +86,7 @@ impl<'a, Rx> Ingress<'a, Rx>
                 | Response::IpAddress(..)
                 | Response::Resolvers(..)
                 | Response::DnsFail
+                | Response::UnlinkFail
                 | Response::IpAddresses(..) => {
                     if let Err(response) = self.response_producer.enqueue(response) {
                         log::error!("failed to enqueue response {:?}", response);

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -357,6 +357,19 @@ named!(
 );
 
 named!(
+    pub unlink_fail<Response>,
+    do_parse!(
+        opt!(crlf) >>
+        tag!("UNLINK") >>
+        crlf >>
+        error >>
+        (
+            Response::UnlinkFail
+        )
+    )
+);
+
+named!(
     pub parse<Response>,
     alt!(
           ok
@@ -378,5 +391,6 @@ named!(
         | dns_resolvers
         | dns_lookup
         | dns_fail
+        | unlink_fail
     )
 );

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -40,6 +40,7 @@ pub enum Command<'a> {
     JoinAp { ssid: &'a str, password: &'a str },
     QueryIpAddress,
     StartConnection(usize, ConnectionType, SocketAddr),
+    CloseConnection(usize),
     Send { link_id: usize, len: usize },
     Receive { link_id: usize, len: usize },
     QueryDnsResolvers,
@@ -95,6 +96,11 @@ impl<'a> Command<'a> {
                 }
                 s as String<U128>
             }
+            Command::CloseConnection(link_id) => {
+                let mut s = String::from("AT+CIPCLOSE=");
+                write!(s, "{}", link_id).unwrap();
+                s
+            }
             Command::Send { link_id, len } => {
                 let mut s = String::from("AT+CIPSEND=");
                 write!(s, "{},{}", link_id, len).unwrap();
@@ -148,6 +154,7 @@ pub enum Response {
     Resolvers(ResolverAddresses),
     IpAddress(IpAddr),
     DnsFail,
+    UnlinkFail,
 }
 
 impl Debug for Response {
@@ -180,6 +187,7 @@ impl Debug for Response {
             Response::IpAddress( v) => f.debug_tuple( "IpAddress").field(v).finish(),
             Response::Resolvers(v) => f.debug_tuple( "Resolvers").field(v).finish(),
             Response::DnsFail => f.write_str("DNS Fail"),
+            Response::UnlinkFail => f.write_str("UnlinkFail"),
         }
     }
 }


### PR DESCRIPTION
This PR send out the `+ATCIPCLOSE` command to the ESP when the socket is closed.

When checking for the result, it also parses `UNLINK ERROR`, which may be returned when the link was already closed from the ESP's perspective.

The socket is only closed internally when the command to the ESP succeeded. As we only know for sure that the link is closed in the ESP, when it responds with `OK` or `UNLINK ERROR`.