### PR TITLE
Fixed leakage of socket, if connect() fails

### DIFF
--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -380,10 +380,10 @@ impl<'a, Tx> Adapter<'a, Tx>
                 Response::Connect(_) => {}
                 Response::Closed(link_id) => {
                     match self.sockets[link_id].state {
-                        SocketState::HalfClosed => {
+                        SocketState::Open | SocketState::HalfClosed => {
                             self.sockets[link_id].state = SocketState::Closed;
                         }
-                        SocketState::Open | SocketState::Connected => {
+                        SocketState::Connected => {
                             self.sockets[link_id].state = SocketState::HalfClosed;
                         }
                         SocketState::Closed => {
@@ -397,6 +397,8 @@ impl<'a, Tx> Adapter<'a, Tx>
     }
 
     pub(crate) fn open(&mut self) -> Result<usize, AdapterError> {
+        self.process_notifications();
+
         if let Some((index, socket)) = self
             .sockets
             .iter_mut()


### PR DESCRIPTION
If opening of a TCP connection fails, ESP8266 usually closes the socket upstream:
> [INFO] [drogue_esp8266::adapter]: writing command AT+CIPSTART=0,"TCP","192.168.0.224",6379
> [INFO] [drogue_esp8266::ingress]: --> Error
> [INFO] [drogue_esp8266::ingress]: --> Closed(0)

The state of the socket stays then either `SocketState::Open` or is set to `SocketState::HalfClosed`
https://github.com/drogue-iot/drogue-esp8266/blob/97e1b9efbf1a367a656dfc7b2f1c7d5d543546b2/src/adapter.rs#L387

The problem is, that socket gets consumed at connect() call, so there is no way for the caller to fully close the socket:
https://github.com/drogue-iot/drogue-esp8266/blob/97e1b9efbf1a367a656dfc7b2f1c7d5d543546b2/src/network.rs#L159

As only fully closed sockets gets emitted by open(), the socket is lost.

My proposal is, to process notifications at open() and set sockets with status  `SocketState::Open` to `SocketState::Close` on close notification. I assume this is safe, as due to a missing connection, there is also no possibility of pending data.

I'm forward to your feedback.