### PR TITLE
Network driver to adapter casting

### DIFF
--- a/src/network.rs
+++ b/src/network.rs
@@ -50,6 +50,10 @@ impl<'a, Tx> Esp8266IpNetworkDriver<'a, Tx>
             adapter: RefCell::new(adapter),
         }
     }
+    
+    pub fn into_adapter(self) -> Adapter<'a, Tx> {
+        self.adapter.into_inner()
+    }
 }
 
 impl<'a, Tx> IpNetworkDriver for Esp8266IpNetworkDriver<'a, Tx>


### PR DESCRIPTION
Sometimes after casting the adapter to network driver, it may be necessary to access the adapter again. For example, if the Wi-Fi connection is lost and needs to be rejoined.

Looking forward to your feedback.